### PR TITLE
Add a formatting script for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: bionic
+
+stages:
+  - build
+
+matrix:
+  include:
+    - name: Static checks (format.sh)
+      stage: build
+      os: linux
+      addons:
+        apt:
+          packages:
+            - dos2unix
+            - recode
+
+script:
+  - bash ./format.sh

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Loops through all text files tracked by Git.
+git grep -zIl '' |
+while IFS= read -rd '' f; do
+    # Exclude csproj and hdr files.
+    if [[ $f == *"csproj" ]]; then
+        continue
+    elif [[ $f == *"hdr" ]]; then
+        continue
+    fi
+    # Ensures that files are UTF-8 formatted.
+    recode UTF-8 $f 2> /dev/null
+    # Ensures that files have LF line endings.
+    dos2unix $f 2> /dev/null
+    # Ensures that files do not contain a BOM.
+    sed -i '1s/^\xEF\xBB\xBF//' "$f"
+    # Ensures that files end with newline characters.
+    tail -c1 < "$f" | read -r _ || echo >> "$f";
+done
+
+git diff > patch.patch
+FILESIZE=$(stat -c%s patch.patch)
+MAXSIZE=5
+
+# If no patch has been generated all is OK, clean up, and exit.
+if (( FILESIZE < MAXSIZE )); then
+    printf "Files in this commit comply with the formatting rules.\n"
+    rm -f patch.patch
+    exit 0
+fi
+
+# A patch has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the formatting rules:\n\n"
+cat patch.patch
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+rm -f patch.patch
+exit 1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This is a simple script which automatically checks and corrects file formatting to comply with POSIX standards. This repo already has all files complying with this script, but I noticed that there were some issues with files missing newlines in the `feature/code-rewrite` branch, and if this script was present, those issues could've been avoided.

To run on Travis, this repo needs to be added on the [Travis CI website](https://travis-ci.org/). The formatting script can also be run locally to fix formatting.

Starting with Godot 3.2, Godot will automatically ensure files end in newlines with its internal editor, but this script can help with fixing up old files, and ensuring this is done with all text files.

**Does this PR introduce a breaking change?**

No.