### PR TITLE
Fixed dialogue path

### DIFF
--- a/godot/src/map/LocalMap.tscn
+++ b/godot/src/map/LocalMap.tscn
@@ -73,7 +73,7 @@ facing = {
 shape = SubResource( 2 )
 
 [node name="Dialogue" parent="GameBoard/Pawns/DialoguePawn/Actions" index="0" instance=ExtResource( 11 )]
-dialogue_file_path = "res://dialogue/data/test_conversation.json"
+dialogue_file_path = "res://src/dialogue/data/test_conversation.json"
 
 [node name="DialogueCombatPawn" parent="GameBoard/Pawns" instance=ExtResource( 8 )]
 position = Vector2( 1160, 600 )


### PR DESCRIPTION
The dialogue forlder was moved in 426a3b18ab050397c541145e49404923720a58b2

**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): Fixes #199
