### PR TITLE
Use drop chance correctly

### DIFF
--- a/godot/src/combat/Rewards.gd
+++ b/godot/src/combat/Rewards.gd
@@ -24,7 +24,7 @@ func _add_reward(battler: Battler):
 	# Appends dictionaries with the form { 'item': Item.tres, 'amount': amount } of dropped items to the drops array.
 	experience_earned += battler.drops.experience
 	for drop in battler.drops.get_drops():
-		if drop.chance - randf() > drop.chance:
+		if drop.chance < 1 and randf() >= drop.chance:
 			continue
 		var amount: int = (
 			1


### PR DESCRIPTION
Given that `randf` output is in the range [0, 1] inclusive, and we want `chance = 0` to mean never, and `chance = 1` to mean always, we need to worry about the edge cases.

We need the `>=` because when `randf() == 0` and `chance == 0` just using `>` would give us the wrong result.

We need to compare against 1 because when `randf() == 1` and `chance == 1` we would get the wrong reasult due to the `>=`.

This is the from I found easier to read.

**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): fixes #201

**Other information**

I had to create a DropItem script for testing the drop. It is not included in the pull request. I'm trying to fix, not add.